### PR TITLE
Use front camera as default camera when using the "Record" option

### DIFF
--- a/Jointify/Views/Screens/ChooseInputView.swift
+++ b/Jointify/Views/Screens/ChooseInputView.swift
@@ -51,12 +51,15 @@ struct ChooseInputView: View {
                 
                 VStack(spacing: 8) { // Buttons
                     
+                    // don't show Record button in simulator to avoid accidental crashes
+                    #if !targetEnvironment(simulator)
                     DefaultButton(action: {
                         self.sourceType = UIImagePickerController.SourceType.camera
                         self.videoPickerSheetIsPresented.toggle()
                     }) {
                         Text("Record").frame(width: 100)
                     }
+                    #endif
                     
                     DefaultButton(action: {
                         self.sourceType = UIImagePickerController.SourceType.photoLibrary

--- a/Jointify/Views/Subviews/ImagePicker.swift
+++ b/Jointify/Views/Subviews/ImagePicker.swift
@@ -50,7 +50,9 @@ struct MediaPicker: UIViewControllerRepresentable {
         imagePicker.mediaTypes = [kUTTypeMovie as String]
         
         // front camera as default
-        imagePicker.cameraDevice = .front
+        if sourceType == .camera {
+            imagePicker.cameraDevice = .front
+        }
         
         imagePicker.allowsEditing = true
         imagePicker.delegate = context.coordinator

--- a/Jointify/Views/Subviews/ImagePicker.swift
+++ b/Jointify/Views/Subviews/ImagePicker.swift
@@ -49,6 +49,9 @@ struct MediaPicker: UIViewControllerRepresentable {
         imagePicker.sourceType = sourceType
         imagePicker.mediaTypes = [kUTTypeMovie as String]
         
+        // front camera as default
+        imagePicker.cameraDevice = .front
+        
         imagePicker.allowsEditing = true
         imagePicker.delegate = context.coordinator
     }

--- a/Jointify/Views/Subviews/ImagePicker.swift
+++ b/Jointify/Views/Subviews/ImagePicker.swift
@@ -26,12 +26,8 @@ struct MediaPicker: UIViewControllerRepresentable {
         // create media picker
         let imagePicker = UIImagePickerController()
         
-        imagePicker.mediaTypes = [kUTTypeMovie as String]
-        imagePicker.allowsEditing = true
-        
-        imagePicker.sourceType = sourceType
-        
-        imagePicker.delegate = context.coordinator
+        // setup
+        setup(this: imagePicker, context)
         
         return imagePicker
     }
@@ -45,6 +41,16 @@ struct MediaPicker: UIViewControllerRepresentable {
         NavigationControllerCoordinator(videoPickerSheetIsPresented: $videoPickerSheetIsPresented,
                     videoURL: $videoURL,
                     sourceType: $sourceType)
+    }
+    
+    fileprivate func setup(this imagePicker: UIImagePickerController, _ context: MediaPicker.Context) {
+        
+        // use video media and video mode in camera as default in respective source type
+        imagePicker.sourceType = sourceType
+        imagePicker.mediaTypes = [kUTTypeMovie as String]
+        
+        imagePicker.allowsEditing = true
+        imagePicker.delegate = context.coordinator
     }
 }
 


### PR DESCRIPTION
The front camera should now open as default

**I couldn't test this on my iPhone and the simulator doesn't have the camera functionality so could you please test it @annalena94?**