### PR TITLE
Closes #20: Measurement instance to result view

### DIFF
--- a/Jointify/Model/Measurement.swift
+++ b/Jointify/Model/Measurement.swift
@@ -24,5 +24,18 @@ struct Measurement {
     var maxROM: Float {
         return frames.map({$0.degree}).max() ?? 0
     }
+    
+    // MARK: Initializers
+    init(date: Date, videoUrl: NSURL?, frames: [MeasurementFrame]) {
+        self.date = date
+        self.videoUrl = videoUrl
+        self.frames = frames
+    }
+    
+    /// creates a mock instance
+    init() {
+        self.date = Date()
+        self.videoUrl = nil
+        self.frames = []
     }
 }

--- a/Jointify/Model/Measurement.swift
+++ b/Jointify/Model/Measurement.swift
@@ -19,9 +19,10 @@ struct Measurement {
     
     // MARK: Computed Instance Properties
     var minROM: Float {
-        return 0 // search through `frames`
+        return frames.map({$0.degree}).min() ?? 0
     }
     var maxROM: Float {
-        return 0 // search through `frames`
+        return frames.map({$0.degree}).max() ?? 0
+    }
     }
 }

--- a/Jointify/Views/Screens/ProcessingView.swift
+++ b/Jointify/Views/Screens/ProcessingView.swift
@@ -24,12 +24,13 @@ struct ProcessingView: View {
     
     // MARK: Body
     var body: some View {
+        
         VStack {
             VStack {
                 
                 // pass analysed images further
                 NavigationLink(destination:
-                    VideoResultView(measurement: measurement),
+                    VideoResultView(measurement: measurement ?? Measurement()),
                                isActive: self.$finishedProcessing) { EmptyView() }
                 Text("Your image is being analysed")
                 

--- a/Jointify/Views/Screens/ResultView.swift
+++ b/Jointify/Views/Screens/ResultView.swift
@@ -17,11 +17,9 @@ struct ResultView: View {
     @State private var homeButtonPressed: Bool = false
 
     // MARK: Stored Instance Properties
-    // TODO: change to Measurement
-    let minValue: Int = -55
-    let maxValue: Int = 90
-    let previousMinValue: Int = -45
-    let previousMaxValue: Int = 80
+    let measurement: Measurement
+    let mockedPreviousMinValue: Int = -45
+    let mockedPreviousMaxValue: Int = 80
     
     // MARK: Body
     var body: some View {
@@ -38,13 +36,13 @@ struct ResultView: View {
                 
                 VStack {
                     HStack(spacing: 16.0) {
-                        Text("Max value: \(maxValue)°")
-                        Text("Min value: \(minValue)°")
+                        Text("Max value: \(measurement.maxROM)°")
+                        Text("Min value: \(measurement.minROM)°")
                     }
                     HStack(spacing: 16.0) {
-                        Text("previous: \(previousMaxValue)°")
+                        Text("previous: \(mockedPreviousMaxValue)°")
                             .foregroundColor(Color.gray)
-                        Text("previous: \(previousMinValue)°")
+                        Text("previous: \(mockedPreviousMinValue)°")
                             .foregroundColor(Color.gray)
                     }
                 }
@@ -75,6 +73,13 @@ struct ResultView: View {
 
 struct ResultView_Previews: PreviewProvider {
     static var previews: some View {
-        ResultView()
+        
+        ResultView(
+            measurement: Measurement(
+                date: Date(),
+                videoUrl: nil,
+                frames: []
+            )
+        )
     }
 }

--- a/Jointify/Views/Screens/VideoResultView.swift
+++ b/Jointify/Views/Screens/VideoResultView.swift
@@ -37,7 +37,7 @@ struct VideoResultView: View {
                 }
             }
             
-            NavigationLink(destination: ResultView(), isActive: self.$goToResultView) {
+            NavigationLink(destination: ResultView(measurement: measurement), isActive: self.$goToResultView) {
                 DefaultButton(action: {
                     self.goToResultView.toggle()
                 }) {

--- a/Jointify/Views/Screens/VideoResultView.swift
+++ b/Jointify/Views/Screens/VideoResultView.swift
@@ -16,7 +16,7 @@ struct VideoResultView: View {
     @State var goToResultView: Bool = false
     
     // MARK: Stored Instance Properties
-    let measurement: Measurement?
+    let measurement: Measurement
     
     // MARK: Body
     var body: some View {
@@ -25,7 +25,7 @@ struct VideoResultView: View {
             Text("The frames (scroll):")
             ScrollView {
                 VStack(spacing: 16) {
-                        ForEach(measurement?.frames ?? [], id: \.self) { frame in
+                    ForEach(measurement.frames, id: \.self) { frame in
                             VStack(spacing: 8) {
                                 Image(uiImage: frame.image)
                                     .resizable()


### PR DESCRIPTION
The ResultView previously held mock data. Now, the original `Measurement` that is created in the `AnalysisView` is passed to the `VideoResultView` and on to the `ResultView`