### PR TITLE
Feature: model quality control

### DIFF
--- a/Jointify.xcodeproj/project.pbxproj
+++ b/Jointify.xcodeproj/project.pbxproj
@@ -159,13 +159,13 @@
 			isa = PBXGroup;
 			children = (
 				21CFEA792497EA0300421B80 /* Joint.swift */,
+				21ED3CFD249A06FD0031199A /* JointName.swift */,
 				21CFEA722497E9F500421B80 /* Pose.swift */,
 				80EF89BD2497F31100E345F0 /* Edge.swift */,
-				21CFEA7E2497EA2600421B80 /* PoseNet.swift */,
-				21CFEA7D2497EA2600421B80 /* PoseNetOutput.swift */,
 				21ED3CFF249A0E250031199A /* Cell.swift */,
 				21ED3D01249A0F4E0031199A /* Side.swift */,
-				21ED3CFD249A06FD0031199A /* JointName.swift */,
+				21CFEA7E2497EA2600421B80 /* PoseNet.swift */,
+				21CFEA7D2497EA2600421B80 /* PoseNetOutput.swift */,
 				21CFEA7B2497EA2600421B80 /* PoseNetInput.swift */,
 				21CFEA732497E9F500421B80 /* PoseBuilder.swift */,
 				21CFEA742497E9F500421B80 /* PoseBuilderConfiguration.swift */,

--- a/Jointify/Model/PoseMachineLearning/Joint.swift
+++ b/Jointify/Model/PoseMachineLearning/Joint.swift
@@ -50,5 +50,4 @@ class Joint {
         self.confidence = confidence
         self.isValid = isValid
     }
- 
 }

--- a/Jointify/Model/PoseMachineLearning/JointName.swift
+++ b/Jointify/Model/PoseMachineLearning/JointName.swift
@@ -10,6 +10,7 @@
 import Foundation
 
 // MARK: - Name
+/// Conformance to Int is necessary for access of the model output
 enum JointName: Int, CaseIterable, CustomStringConvertible {
     case nose
     case leftEye

--- a/Jointify/Model/PoseMachineLearning/PoseNet.swift
+++ b/Jointify/Model/PoseMachineLearning/PoseNet.swift
@@ -59,16 +59,21 @@ class PoseNet {
         static let jointColor: UIColor = UIColor.systemPink
         // Degrees that will be subtraced from the measured angle
         static let neutralNullAngle: Float = 90.0
-        // Minimum confidence that each joint has to conform to
+        /// Minimum confidence value that each drawn joint in each frame has to conform to
+        ///
+        /// E.g. if you analyse the right knee, the joints rightHip, rightKnee & rightAnkle
+        /// must have a confidence value above the specified threshold, if this is not fulfilled
+        /// the whole image is rejected
         static let confidenceThreshold: Double = 0.70
     }
     
-    let side: Side
+    // MARK: Stored Instance Properties
+    private var degree: Float = 0.0
+    private let side: Side
     private let jointSegments: [JointSegment]
     private let selectedJointNames: [JointName]
-    var degree: Float = 0.0
-    // Dictionary for the coordinates of all joints
-    var jointPositions: [String: Float] = [:]
+    // mapping the recognized Joints to their respective coordinates on the canvas
+    private var jointPositions: [String: Float] = [:]
 
     // MARK: Initializers
     init(side: Side) {

--- a/Jointify/Model/PoseMachineLearning/PoseNet.swift
+++ b/Jointify/Model/PoseMachineLearning/PoseNet.swift
@@ -68,8 +68,8 @@ class PoseNet {
     private let selectedJointNames: [JointName]
     var degree: Float = 0.0
     // Dictionary for the coordinates of all joints
-    var jointPositions = [String: Float]()
-    
+    var jointPositions: [String: Float] = [:]
+
     // MARK: Initializers
     init(side: Side) {
         self.side = side

--- a/Jointify/Model/PoseMachineLearning/PoseNet.swift
+++ b/Jointify/Model/PoseMachineLearning/PoseNet.swift
@@ -167,9 +167,9 @@ class PoseNet {
         return dstImage
     }
     
-    // Get X and Y coordinates of joints and place them in the dictionary
-    // This function depends on pose, which only is created in the predict() function
-    // Thus, it can only be called once the prediction function is done
+    /// Get X and Y coordinates of joints and place them in the dictionary
+    /// This function depends on pose, which only is created in the predict() function
+    /// Thus, it can only be called once the prediction function is done
     func fillJointCoordinatesDictionaries() {
         guard let pose = pose else {
             print("Error. No pose could be detected.")

--- a/Jointify/TypeExtensions/UIImage+Extensions.swift
+++ b/Jointify/TypeExtensions/UIImage+Extensions.swift
@@ -24,3 +24,4 @@ extension UIImage {
     }
     
 }
+

--- a/Jointify/TypeExtensions/UIImage+Extensions.swift
+++ b/Jointify/TypeExtensions/UIImage+Extensions.swift
@@ -12,7 +12,6 @@ import UIKit
 
 // MARK: UIImage extension
 extension UIImage {
-    
     // MARK: Stored Instance Methods
     // resize the image to the correct input size
     func resizeTo(size: CGSize) -> UIImage? {
@@ -22,6 +21,4 @@ extension UIImage {
         UIGraphicsEndImageContext()
         return resizedImage
     }
-    
 }
-

--- a/Jointify/Views/Screens/ProcessingView.swift
+++ b/Jointify/Views/Screens/ProcessingView.swift
@@ -116,13 +116,19 @@ struct ProcessingView: View {
                 print("Analysing frame \(frameCount)/\(frames.count)")
                 
                 let drawnImage = poseNet.predict(frame)
+                
+                let outputQualityAcceptable = poseNet.assessOutputQuality()
 
-                returnMeasurementFrames.append(
-                    MeasurementFrame(
-                        degree: poseNet.calcAngleBetweenJoints(),
-                        image: drawnImage
+                // Only append measurement frame if it fulfills quality criteria
+                if outputQualityAcceptable {
+                    returnMeasurementFrames.append(
+                        MeasurementFrame(
+                            degree: poseNet.calcAngleBetweenJoints(),
+                            image: drawnImage
+                        )
                     )
-                )
+                }
+                
                 self.progress += 1
 
             }

--- a/Jointify/Views/Screens/ProcessingView.swift
+++ b/Jointify/Views/Screens/ProcessingView.swift
@@ -18,11 +18,13 @@ struct ProcessingView: View {
     
     // MARK: State Instance Propoerties
     @State private var progress: Int = 0
-    @State private var removedFramesCounter = 0
-    private let acceptedFramesThreshold: Double = 0.7
     @State private var total: Int = 0
     @State private var finishedProcessing: Bool = false
     @State private var measurement: Measurement?
+    @State private var acceptedFramesCounter = 0
+    
+    // MARK: Stored Instance Properties
+    private let acceptedFramesThreshold: Double = 0.7
     
     // MARK: Body
     var body: some View {
@@ -123,7 +125,7 @@ struct ProcessingView: View {
 
                 // Only append measurement frame if it fulfills quality criteria
                 if outputQualityAcceptable {
-                    self.removedFramesCounter += 1
+                    self.acceptedFramesCounter += 1
                     returnMeasurementFrames.append(
                         MeasurementFrame(
                             degree: poseNet.calcAngleBetweenJoints(),
@@ -136,10 +138,9 @@ struct ProcessingView: View {
 
             }
             
-            let acceptedFramesPercentage = Double(self.removedFramesCounter) / Double(self.progress)
+            let acceptedFramesPercentage = Double(self.acceptedFramesCounter) / Double(self.progress)
             
             if acceptedFramesPercentage < self.acceptedFramesThreshold {
-                // TODO: throw proper error message at user
                 print("Error. Please submit another video.")
             }
             

--- a/Jointify/Views/Screens/ProcessingView.swift
+++ b/Jointify/Views/Screens/ProcessingView.swift
@@ -18,6 +18,8 @@ struct ProcessingView: View {
     
     // MARK: State Instance Propoerties
     @State private var progress: Int = 0
+    @State private var removedFramesCounter = 0
+    private let acceptedFramesThreshold: Double = 0.7
     @State private var total: Int = 0
     @State private var finishedProcessing: Bool = false
     @State private var measurement: Measurement?
@@ -121,6 +123,7 @@ struct ProcessingView: View {
 
                 // Only append measurement frame if it fulfills quality criteria
                 if outputQualityAcceptable {
+                    self.removedFramesCounter += 1
                     returnMeasurementFrames.append(
                         MeasurementFrame(
                             degree: poseNet.calcAngleBetweenJoints(),
@@ -131,6 +134,13 @@ struct ProcessingView: View {
                 
                 self.progress += 1
 
+            }
+            
+            let acceptedFramesPercentage = Double(self.removedFramesCounter) / Double(self.progress)
+            
+            if acceptedFramesPercentage < self.acceptedFramesThreshold {
+                // TODO: throw proper error message at user
+                print("Error. Please submit another video.")
             }
             
             // send when done


### PR DESCRIPTION
Implemented two quality checks for the model output:
- confidence threshold >= 0.7
- x coordinate check for left and right joint

What works:
- removing the images and measurements and not displaying them to the user
- printing and error message in the console if less than 70% of the images can be used

What does not work:
- displaying error message to the user (this should be done in a later iteration)
- code runs quite slowly, will need to move the functions around to increase the speed of the analysis

DISCLAIMER (mostly for @lgerhardt45 ):
I'm aware that there is one open warning message regarding the cyclomatic complexity of the assessQuality() function, but this does not matter for now, since I need to come with another enum logic anyways, if we want to include more joints! So please let's make an exception and ignore it for now ;)