### PR TITLE
Remove redundant VStacks in WelcomeView and InstructionsView

### DIFF
--- a/Jointify/Views/Screens/InstructionsView.swift
+++ b/Jointify/Views/Screens/InstructionsView.swift
@@ -43,21 +43,18 @@ struct InstructionsView: View {
                 
                 Spacer()
                 
-                // Move video data to ProcessingView
-                VStack(spacing: 16.0) {
-                    NavigationLink(
-                        destination: ChooseInputView(
-                        ),
-                        isActive: self.$understoodButtonPressed
-                    ) {
-                        DefaultButton(action: {
-                            // activate NavigationLink to ChooseInputView
-                            self.understoodButtonPressed.toggle()
-                        }) {
-                            Text("I understand")
-                                .frame(width: geometry.size.width / 3.0)
-                        } }
-                }
+                // "I understand" button to ChooseInputView
+                NavigationLink(
+                    destination: ChooseInputView(),
+                    isActive: self.$understoodButtonPressed
+                ) {
+                    DefaultButton(action: {
+                        // activate NavigationLink to ChooseInputView
+                        self.understoodButtonPressed.toggle()
+                    }) {
+                        Text("I understand")
+                            .frame(width: geometry.size.width / 3.0)
+                    } }
             }.padding(.bottom, 32)
                 .navigationBarTitle(Text("Instructions"), displayMode: .inline)
                 .navigationBarHidden(self.isNavigationBarHidden) // is turned to 'false' in WelcomeView

--- a/Jointify/Views/Screens/WelcomeView.swift
+++ b/Jointify/Views/Screens/WelcomeView.swift
@@ -30,7 +30,7 @@ struct WelcomeView: View {
         // starts the navigation stack (screens are loaded "on top" of each other
         NavigationView {
             
-            //GeometryReader to allow for percentage alignments
+            // GeometryReader to allow for percentage alignments
             GeometryReader { geometry in
                 
                 // Outer VStack
@@ -50,20 +50,18 @@ struct WelcomeView: View {
                     
                     Spacer()
                     
-                    // Navigation
-                    VStack(spacing: 16.0) {
-                        NavigationLink(
-                            destination: InstructionsView(
-                                isNavigationBarHidden: self.$isNavigationBarHidden),
-                            isActive: self.$newRecordButtonPressed) {
-                                DefaultButton(action: {
-                                    self.newRecordButtonPressed.toggle()
-                                    self.isNavigationBarHidden = false
-                                }) {
-                                    Text("Start")
-                                        .frame(width: geometry.size.width / 3.0)
-                                }
-                        }
+                    // "Start" button to InstructionsView
+                    NavigationLink(
+                        destination: InstructionsView(
+                            isNavigationBarHidden: self.$isNavigationBarHidden),
+                        isActive: self.$newRecordButtonPressed) {
+                            DefaultButton(action: {
+                                self.newRecordButtonPressed.toggle()
+                                self.isNavigationBarHidden = false
+                            }) {
+                                Text("Start")
+                                    .frame(width: geometry.size.width / 3.0)
+                            }
                     }
                     
                     Spacer()


### PR DESCRIPTION
Just a quick fix because I saw two redundant VStacks (with just one element) in `WelcomeView` and `InstructionsView`