### PR TITLE
Only allow portrait mode

### DIFF
--- a/Jointify/Info.plist
+++ b/Jointify/Info.plist
@@ -52,8 +52,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>


### PR DESCRIPTION
The app isn't ready and not yet made to support landscape mode so it's turned off for now.