### PR TITLE
Quickfix: prevent adding non-successful measurements.

### DIFF
--- a/Jointify/Views/Screens/ProcessingView.swift
+++ b/Jointify/Views/Screens/ProcessingView.swift
@@ -84,8 +84,10 @@ struct ProcessingView: View {
                         )
                         self.measurement = measurement
                         
-                        // save to DataHandler
-                        DataHandler.saveNewMeasurement(measurement: measurement)
+                        // save to DataHandler only if analysis was successfull
+                        if !measurement.frames.isEmpty {
+                            DataHandler.saveNewMeasurement(measurement: measurement)
+                        }
                         
                         // trigger navigation to VideoResultView
                         self.finishedProcessing.toggle()


### PR DESCRIPTION
This is a quickfix for a problem we briefly discussed yesterday. The logic is build upon the logic from yesterday's PR. Let me know if you have any doubts about this solution.