### PR TITLE
[#67] Quickfix delete pre-set mail recipient

### DIFF
--- a/Jointify/Views/Subviews/MailView.swift
+++ b/Jointify/Views/Subviews/MailView.swift
@@ -61,7 +61,6 @@ struct MailView: UIViewControllerRepresentable {
         messageBody += "\n\nplease find attached the copy of my recent ROM measurement."
         
         // setup compose view
-        composeVC.setToRecipients(["lukas.gerhardt@onlinehome.de"])
         composeVC.setMessageBody(messageBody, isHTML: false)
         composeVC.setSubject("ROM measurement from today")
         


### PR DESCRIPTION
I deleted the line which automatically sets the email so that the email recipient is blank. 