### PR TITLE
#64 extend rather than crop frames

### DIFF
--- a/Jointify/Model/PoseMachineLearning/PoseNetPredictionOutput.swift
+++ b/Jointify/Model/PoseMachineLearning/PoseNetPredictionOutput.swift
@@ -18,4 +18,5 @@ struct PoseNetPredictionOutput {
     let image: CGImage
     let outputQualityAcceptable: Bool
     let pose: Pose
+    let originalFrameSize: CGSize
 }

--- a/Jointify/TypeExtensions/UIImage+Extensions.swift
+++ b/Jointify/TypeExtensions/UIImage+Extensions.swift
@@ -13,28 +13,6 @@ import UIKit
 // MARK: UIImage extension
 extension UIImage {
     
-    // MARK: Stored Instance Methods
-    func extendToSquare() -> UIImage? {
-        let originalImage = self
-        let originalSize = originalImage.size
-        let originalWidth = originalSize.width
-        let originalHeight = originalSize.height
-        
-        // set extendedSize to square (width = height)
-        let extendedSize = CGSize(width: originalHeight, height: originalHeight)
-            
-        // start drawing environment with size = extended square
-        UIGraphicsBeginImageContextWithOptions(extendedSize, false, self.scale)
-        
-        // draw original image in top left corner
-        originalImage.draw(in: CGRect(x: 0, y: 0, width: originalWidth, height: originalHeight))
-        
-        let squared = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        
-        return squared
-    }
-    
     /// Scales down width of image to the given height, while maintaining the aspect ratio
     /// returns:
     /// - self scaled down to given height
@@ -52,97 +30,75 @@ extension UIImage {
         let scaledSize = CGSize(width: scaleToWidth, height: scaleToHeight)
         
         // start drawing environment with size = extended square
-        print("Scaling image from \(originalWidth) * \(originalHeight) to \(scaleToWidth) * \(scaleToHeight)")
         UIGraphicsBeginImageContextWithOptions(scaledSize, false, self.scale)
         
         // draw original image in top left corner
         originalImage.draw(in: CGRect(x: 0, y: 0, width: scaleToWidth, height: scaleToHeight))
         
         let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
-        print("finished scaling image to \(scaleToWidth) * \(scaleToHeight)")
+        
         UIGraphicsEndImageContext()
         
         return scaledImage
     }
     
-    /// resize the image size the correct input size by cropping it size square
-    /// from https://stackoverflow.com/a/38777678
-    func resizeTo(size: CGSize) -> UIImage? {
-         guard let cgimage = self.cgImage else { return self }
-
-           let contextImage: UIImage = UIImage(cgImage: cgimage)
-
-           guard let newCgImage = contextImage.cgImage else { return self }
-
-           let contextSize: CGSize = contextImage.size
-
-           // Set size square
-           var posX: CGFloat = 0.0
-           var posY: CGFloat = 0.0
-           let cropAspect: CGFloat = size.width / size.height
-
-           var cropWidth: CGFloat = size.width
-           var cropHeight: CGFloat = size.height
-
-           if size.width > size.height { // Landscape
-               cropWidth = contextSize.width
-               cropHeight = contextSize.width / cropAspect
-               posY = (contextSize.height - cropHeight) / 2
-           } else if size.width < size.height { // Portrait
-               cropHeight = contextSize.height
-               cropWidth = contextSize.height * cropAspect
-               posX = (contextSize.width - cropWidth) / 2
-           } else { // Square
-               if contextSize.width >= contextSize.height { // Square on landscape (or square)
-                   cropHeight = contextSize.height
-                   cropWidth = contextSize.height * cropAspect
-                   posX = (contextSize.width - cropWidth) / 2
-               } else { // Square on portrait
-                   cropWidth = contextSize.width
-                   cropHeight = contextSize.width / cropAspect
-                   posY = (contextSize.height - cropHeight) / 2
-               }
-           }
-
-           let rect: CGRect = CGRect(x: posX, y: posY, width: cropWidth, height: cropHeight)
-
-           // Create bitmap image from context using the rect
-        guard let imageRef: CGImage = newCgImage.cropping(to: rect) else { return self}
-
-           // Create a new image based on the imageRef and rotate back size the original orientation
-           let cropped: UIImage = UIImage(cgImage: imageRef, scale: self.scale, orientation: self.imageOrientation)
-
-           UIGraphicsBeginImageContextWithOptions(size, false, self.scale)
-           cropped.draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
-           let resized = UIGraphicsGetImageFromCurrentImageContext()
-           UIGraphicsEndImageContext()
-
-           return resized ?? self
+    // MARK: Stored Instance Methods
+    func extendToSquare() -> UIImage? {
+        let originalImage = self
+        let originalSize = originalImage.size
+        let originalWidth = originalSize.width
+        let originalHeight = originalSize.height
+        
+        // set extendedSize to square (width = height)
+        let extendedSize = CGSize(width: originalHeight, height: originalHeight)
+        
+        // start drawing environment with size = extended square
+        UIGraphicsBeginImageContextWithOptions(extendedSize, false, self.scale)
+        
+        // draw original image in top left corner
+        originalImage.draw(in: CGRect(x: 0, y: 0, width: originalWidth, height: originalHeight))
+        
+        let squared = UIGraphicsGetImageFromCurrentImageContext()
+        
+        UIGraphicsEndImageContext()
+        
+        return squared
     }
     
     /// Cuts self to the given width from the left side
+    /// Modified from https://stackoverflow.com/a/38777678
     /// returns:
     /// - new UIImage from self with given width
     func cutToWidthFromLeft(_ cutToWidth: CGFloat) -> UIImage? {
-        let originalImage = self
+        guard let cgimage = self.cgImage else { return self }
         
-        let originalHeight = originalImage.size.height
-        let originalWidth = originalImage.size.width
+        let contextImage: UIImage = UIImage(cgImage: cgimage)
         
-        let cutToSize = CGSize(width: cutToWidth, height: originalHeight)
+        guard let newCgImage = contextImage.cgImage else { return self }
         
-        // start drawing environment with size = extended square
-        print("Cutting image from \(originalWidth) * \(originalWidth) to \(cutToSize.width) * \(cutToSize.height)")
+        let cutToSize = CGSize(width: cutToWidth,
+                               height: newCgImage.size.height)
+        
+        let rect: CGRect = CGRect(origin: .zero,
+                                  size: cutToSize)
+        
+        // Create bitmap image from context using the rect
+        guard let imageRef: CGImage = newCgImage.cropping(to: rect) else { return self }
+        
+        // Create a new image based on the imageRef and rotate back size the original orientation
+        let cropped: UIImage = UIImage(cgImage: imageRef,
+                                       scale: self.scale,
+                                       orientation: self.imageOrientation)
+        
         UIGraphicsBeginImageContextWithOptions(cutToSize, false, self.scale)
         
-        // draw original image in top left corner
-        originalImage.draw(in: CGRect(x: 0, y: 0, width: cutToSize.width, height: cutToSize.height))
+        cropped.draw(in: CGRect(origin: .zero,
+                                size: cutToSize))
         
-        let cutToImage = UIGraphicsGetImageFromCurrentImageContext()
-        print("finished scaling image to \(cutToSize.width) * \(cutToSize.height)")
+        let resized = UIGraphicsGetImageFromCurrentImageContext()
+        
         UIGraphicsEndImageContext()
         
-        return cutToImage
-        
+        return resized ?? self
     }
 }

--- a/Jointify/TypeExtensions/UIImage+Extensions.swift
+++ b/Jointify/TypeExtensions/UIImage+Extensions.swift
@@ -35,6 +35,36 @@ extension UIImage {
         return squared
     }
     
+    /// Scales down width of image to the given height, while maintaining the aspect ratio
+    /// returns:
+    /// - self scaled down to given height
+    func scaleTo(heigth scaleToHeight: CGFloat) -> UIImage? {
+        
+        let originalImage = self
+        
+        let originalHeight = originalImage.size.height
+        let originalWidth = originalImage.size.width
+        
+        let scaleRatio = originalHeight / scaleToHeight
+        
+        let scaleToWidth = originalWidth / scaleRatio
+        
+        let scaledSize = CGSize(width: scaleToWidth, height: scaleToHeight)
+        
+        // start drawing environment with size = extended square
+        print("Scaling image from \(originalWidth) * \(originalHeight) to \(scaleToWidth) * \(scaleToHeight)")
+        UIGraphicsBeginImageContextWithOptions(scaledSize, false, self.scale)
+        
+        // draw original image in top left corner
+        originalImage.draw(in: CGRect(x: 0, y: 0, width: scaleToWidth, height: scaleToHeight))
+        
+        let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
+        print("finished scaling image to \(scaleToWidth) * \(scaleToHeight)")
+        UIGraphicsEndImageContext()
+        
+        return scaledImage
+    }
+    
     /// resize the image size the correct input size by cropping it size square
     /// from https://stackoverflow.com/a/38777678
     func resizeTo(size: CGSize) -> UIImage? {
@@ -88,5 +118,31 @@ extension UIImage {
            UIGraphicsEndImageContext()
 
            return resized ?? self
+    }
+    
+    /// Cuts self to the given width from the left side
+    /// returns:
+    /// - new UIImage from self with given width
+    func cutToWidthFromLeft(_ cutToWidth: CGFloat) -> UIImage? {
+        let originalImage = self
+        
+        let originalHeight = originalImage.size.height
+        let originalWidth = originalImage.size.width
+        
+        let cutToSize = CGSize(width: cutToWidth, height: originalHeight)
+        
+        // start drawing environment with size = extended square
+        print("Cutting image from \(originalWidth) * \(originalWidth) to \(cutToSize.width) * \(cutToSize.height)")
+        UIGraphicsBeginImageContextWithOptions(cutToSize, false, self.scale)
+        
+        // draw original image in top left corner
+        originalImage.draw(in: CGRect(x: 0, y: 0, width: cutToSize.width, height: cutToSize.height))
+        
+        let cutToImage = UIGraphicsGetImageFromCurrentImageContext()
+        print("finished scaling image to \(cutToSize.width) * \(cutToSize.height)")
+        UIGraphicsEndImageContext()
+        
+        return cutToImage
+        
     }
 }

--- a/Jointify/TypeExtensions/UIImage+Extensions.swift
+++ b/Jointify/TypeExtensions/UIImage+Extensions.swift
@@ -14,6 +14,27 @@ import UIKit
 extension UIImage {
     
     // MARK: Stored Instance Methods
+    func extendToSquare() -> UIImage? {
+        let originalImage = self
+        let originalSize = originalImage.size
+        let originalWidth = originalSize.width
+        let originalHeight = originalSize.height
+        
+        // set extendedSize to square (width = height)
+        let extendedSize = CGSize(width: originalHeight, height: originalHeight)
+            
+        // start drawing environment with size = extended square
+        UIGraphicsBeginImageContextWithOptions(extendedSize, false, self.scale)
+        
+        // draw original image in top left corner
+        originalImage.draw(in: CGRect(x: 0, y: 0, width: originalWidth, height: originalHeight))
+        
+        let squared = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return squared
+    }
+    
     /// resize the image size the correct input size by cropping it size square
     /// from https://stackoverflow.com/a/38777678
     func resizeTo(size: CGSize) -> UIImage? {

--- a/Jointify/Views/Screens/ProcessingView.swift
+++ b/Jointify/Views/Screens/ProcessingView.swift
@@ -217,14 +217,22 @@ struct ProcessingView: View {
                         return
                 }
                 
-                let drawnMinImage = poseNet.show(poseNetMin.image, poseNetMin.pose)
-                let drawnMaxImage = poseNet.show(poseNetMax.image, poseNetMax.pose)
+                let drawnMinImage = poseNet.show(frame: poseNetMin.image,
+                                                 pose: poseNetMin.pose)
+                let drawnMaxImage = poseNet.show(frame: poseNetMax.image,
+                                                 pose: poseNetMax.pose)
+                
+                guard let finalMinImage = drawnMinImage.cutToWidthFromLeft(poseNetMin.originalFrameSize.width),
+                    let finalMaxImage = drawnMaxImage.cutToWidthFromLeft(poseNetMax.originalFrameSize.width) else {
+                        print("Error. Image could not be cut to original width.")
+                        return
+                }
                 
                 // successfully derived a Measurement instance
                 let measurement = Measurement(
                     date: Date(),
-                    minROMFrame: MeasurementFrame(degree: poseNetMin.degree, image: drawnMinImage),
-                    maxROMFrame: MeasurementFrame(degree: poseNetMax.degree, image: drawnMaxImage)
+                    minROMFrame: MeasurementFrame(degree: poseNetMin.degree, image: finalMinImage),
+                    maxROMFrame: MeasurementFrame(degree: poseNetMax.degree, image: finalMaxImage)
                 )
                 
                 // success when done

--- a/Jointify/Views/Subviews/InstructionContent.swift
+++ b/Jointify/Views/Subviews/InstructionContent.swift
@@ -32,31 +32,23 @@ struct InstructionContent: View {
     "1) Go to your Gallery and start editing the video."
     
     let videoEditingInstructions2 =
-    "2) Trim video so that the first frame is the initial position as indicated above."
+    "2) Cut video such that the first frame is the initial position as indicated above."
     
     let videoEditingInstructions3 =
-    "3) Trim video so that the last frame is the initial position as indicated above."
-    
-    let videoEditingInstructions4 =
-    "4) Select the crop symbol."
-    
-    let videoEditingInstructions5 =
-    "5) Select the resize symbol."
-    
-    let videoEditingInstructions6 =
-    "6) Select square format and press done."
-    
-    let privacyDisclaimer =
-    "No submitted videos will be saved or leave your phone in any way. All these restrictions are simply needed to ensure correct measurement results."
+    "3) Cut video such that the last frame is the initial position as indicated above."
     
     let howToImprove = [
         "Find a suitable spot with as little visual distraction as possible. The analysis works best in front of a plain white wall.",
-        "Place your mobile phone roughly 3 meters away from you on a object which is at least 60 centimetres high (e.g. a chair) or on the floor. It is important that your whole body is in the centre of the picture, since you have to submit a video in square format.",
-        "Make sure that your face is visible (no caps or similar), as it helps the analysis to identify your complete body pose.",
+        "Place your mobile phone on a object (e.g. a chair) or on the floor.",
+        "Make sure that your face is visible (no caps or similar) and show the palms of your hands.",
         "Please wear short pants or underwear, since trousers can distort the measurement results.",
         "Please be barefoot.",
-        "Please ensure that there is no lighting source in the background facing the camera (e.g. windows)."
+        "Please ensure that there is no lighting source in the background facing the camera (e.g. windows).",
+        "Make sure to excecute the movement slow and steady."
     ]
+    
+    let privacyDisclaimer =
+    "No submitted videos will be saved or leave your phone in any way. All these restrictions are simply needed to ensure correct measurement results."
     // swiftlint:enable line_length
     
     // MARK: Body
@@ -70,6 +62,9 @@ struct InstructionContent: View {
                 VStack {
                     
                     InstructionHeadline(headline: "Recording Instructions")
+                    
+                    Text("Make sure that your whole body is visible in the video.")
+                        .multilineTextAlignment(.center)
                     
                     ScrollView(.horizontal) {
                         HStack(alignment: .top, spacing: 16) {
@@ -123,21 +118,6 @@ struct InstructionContent: View {
                             InstructionPoint(
                                 text: videoEditingInstructions3,
                                 image: Image("TrimEnd"),
-                                width: instructionPointWidth)
-                            
-                            InstructionPoint(
-                                text: videoEditingInstructions4,
-                                image: Image("CropStarts"),
-                                width: instructionPointWidth)
-                            
-                            InstructionPoint(
-                                text: videoEditingInstructions5,
-                                image: Image("CropMid"),
-                                width: instructionPointWidth)
-                            
-                            InstructionPoint(
-                                text: videoEditingInstructions6,
-                                image: Image("CropEnd"),
                                 width: instructionPointWidth)
                             
                         }.padding(.all, 8)


### PR DESCRIPTION
Implemented the long awaited new cropping technique.

Now it is possible to submit any video. It does not need to be in the squared format anymore :)

Therefore we also changed the instructions and deleted the now unnecessary images and texts about how to crop you video to a square.

<img width="532" alt="Screenshot 2020-07-04 at 14 26 51" src="https://user-images.githubusercontent.com/59480102/86512437-9eb38a80-be02-11ea-8d5b-bcfb9e33100a.png">
<img width="532" alt="Screenshot 2020-07-04 at 14 27 11" src="https://user-images.githubusercontent.com/59480102/86512443-a2dfa800-be02-11ea-9225-730476ea0694.png">
<img width="532" alt="Screenshot 2020-07-04 at 14 27 44" src="https://user-images.githubusercontent.com/59480102/86512444-a410d500-be02-11ea-8fc3-6c6a3e3286f0.png"> <img width="532" alt="Screenshot 2020-07-04 at 14 27 48" src="https://user-images.githubusercontent.com/59480102/86512445-a5da9880-be02-11ea-9f38-c1d5094ff62b.png">
