### PR TITLE
Grey out the record button and show an alert when clicked

### DIFF
--- a/Jointify/Views/Screens/ChooseInputView.swift
+++ b/Jointify/Views/Screens/ChooseInputView.swift
@@ -25,6 +25,12 @@ struct ChooseInputView: View {
     /// trigger for navigation to ProcessingView
     @State var goToProcessingView: Bool = false
     
+    // MARK: Recording Not Yet Supported Properties
+    @State var showRecordingNotSupportedAlert: Bool = false
+    let recordingSupported: Bool = false
+    // swiftlint:disable:next line_length
+    let recordingNotSupportedText = "Currently, the recording in the app is not supported. Please use the Camera app to record the video and modify it according to the instructions."
+    
     // MARK: Body
     var body: some View {
         
@@ -81,16 +87,20 @@ struct ChooseInputView: View {
                     // Buttons
                     VStack(spacing: 16) {
                         
-                        // don't show Record button in simulator to avoid accidental crashes
-                        #if !targetEnvironment(simulator)
-                        DefaultButton(action: {
-                            self.sourceType = UIImagePickerController.SourceType.camera
-                            self.videoPickerSheetIsPresented.toggle()
+                        // Record
+                        DefaultButton(mode: .disabled,
+                                      action: {
+                            if self.recordingSupported {
+                                self.sourceType = UIImagePickerController.SourceType.camera
+                                self.videoPickerSheetIsPresented.toggle()
+                            } else {
+                                self.showRecordingNotSupportedAlert.toggle()
+                            }
                         }) {
                             Text("Record").frame(width: geometry.size.width / 3.0)
                         }
-                        #endif
                         
+                        // Gallery
                         DefaultButton(action: {
                             self.sourceType = UIImagePickerController.SourceType.photoLibrary
                             self.videoPickerSheetIsPresented.toggle()
@@ -109,6 +119,14 @@ struct ChooseInputView: View {
                             sourceType: self.$sourceType,
                             videoURL: self.$videoUrl)
                     }
+                        
+                    .alert(isPresented: self.$showRecordingNotSupportedAlert) {
+                        Alert(
+                            title: Text("Recording not supported yet"),
+                            message: Text(self.recordingNotSupportedText),
+                            dismissButton: .cancel(Text("Dismiss")))
+                    }
+                    
                 }.padding(.bottom, 32)
             }
         }


### PR DESCRIPTION
We disabled the Record button in the app as time cutting/ trimming is not supported yet. The button is greyed out and when clicked, an alert is shown. Compare screenshots attached: 

![Screenshot 2020-07-04 at 14 48 48](https://user-images.githubusercontent.com/40395744/86512847-cc4e0300-be05-11ea-8a48-a31431367cea.png) ![Screenshot 2020-07-04 at 14 48 54](https://user-images.githubusercontent.com/40395744/86512848-ce17c680-be05-11ea-9744-b3c315e29792.png)
